### PR TITLE
TME-1314: remove deprecated iam perms from template

### DIFF
--- a/iam.tf
+++ b/iam.tf
@@ -94,7 +94,6 @@ data "aws_iam_policy_document" "cloudtrail_manager_iam_document" {
   statement {
     actions = [
       "sqs:DeleteMessage",
-      "sqs:DeleteMessageBatch",
       "sqs:ReceiveMessage"
     ]
     resources = [aws_sqs_queue.cloudtrail_queue.arn]


### PR DESCRIPTION
> remove deprecated iam perm `sqs:DeleteMessageBatch` from CF template
See [comments in this ticket](https://expel-io.atlassian.net/browse/TME-1314) for more info