### PR TITLE
TME-1336: add kms encryption as non optional

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,27 @@
+**/.terraform/*
+
+# .tfstate files
+*.tfstate
+*.tfstate.*
+*.terraform.lock.*
+
+# Crash log files
+crash.log
+crash.*.log
+
+# Ignore override files as they are usually used to override resources locally and so
+# are not checked in
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+
+# Include override files you do wish to add to version control using negated pattern
+# !example_override.tf
+
+# Include tfplan files to ignore the plan output of command: terraform plan -out=tfplan
+# example: *tfplan*
+
+# Ignore CLI configuration files
+.terraformrc
+terraform.rc

--- a/README.md
+++ b/README.md
@@ -49,7 +49,6 @@ have an AWS Organization or already have a CloudTrail you want to re-use.
 | <a name="input_enable_bucket_access_logging"></a> [enable\_bucket\_access\_logging](#input\_enable\_bucket\_access\_logging) | Access logging provides detailed records for the requests that are made to an Amazon S3 bucket. | `bool` | `true` | no |
 | <a name="input_enable_bucket_encryption_key_rotation"></a> [enable\_bucket\_encryption\_key\_rotation](#input\_enable\_bucket\_encryption\_key\_rotation) | If `enable_s3_encryption` is set to true, enabling key rotation will rotate the KMS keys used for S3 bucket encryption. | `bool` | `true` | no |
 | <a name="input_enable_bucket_versioning"></a> [enable\_bucket\_versioning](#input\_enable\_bucket\_versioning) | Enable to protect against accidental/malicious removal or modification of S3 objects. | `bool` | `true` | no |
-| <a name="input_enable_cloudtrail_bucket_encryption"></a> [enable\_cloudtrail\_bucket\_encryption](#input\_enable\_cloudtrail\_bucket\_encryption) | Enable to encrypt objects in the cloudtrail bucket. | `bool` | `true` | no |
 | <a name="input_enable_cloudtrail_log_file_validation"></a> [enable\_cloudtrail\_log\_file\_validation](#input\_enable\_cloudtrail\_log\_file\_validation) | Validates that a log file was not modified, deleted, or unchanged after CloudTrail delivered it. | `bool` | `true` | no |
 | <a name="input_enable_organization_trail"></a> [enable\_organization\_trail](#input\_enable\_organization\_trail) | When enabled, log events for the management account and all member accounts. | `bool` | `false` | no |
 | <a name="input_enable_sqs_encryption"></a> [enable\_sqs\_encryption](#input\_enable\_sqs\_encryption) | Enable server-side encryption (SSE) of message content with SQS-owned encryption keys. | `bool` | `true` | no |
@@ -74,7 +73,6 @@ have an AWS Organization or already have a CloudTrail you want to re-use.
 | [aws_iam_policy.cloudtrail_manager_iam_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_role.expel_assume_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role_policy_attachment.cloudtrail_manager_role_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
-| [aws_kms_key.access_logging_bucket_encryption_key](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_key) | resource |
 | [aws_kms_key.cloudtrail_bucket_encryption_key](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_key) | resource |
 | [aws_s3_bucket.cloudtrail_access_log_bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket) | resource |
 | [aws_s3_bucket.cloudtrail_bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket) | resource |

--- a/examples/basic/main.tf
+++ b/examples/basic/main.tf
@@ -14,19 +14,18 @@ provider "aws" {
 module "expel_aws_cloudtrail_integration" {
   source = "../../"
 
-  expel_customer_organization_guid        = var.expel_customer_organization_guid
-  expel_assume_role_session_name          = "ExpelServiceAssumeRoleForCloudTrailAccess"
-  queue_message_retention_days            = 10
+  expel_customer_organization_guid = var.expel_customer_organization_guid
+  expel_assume_role_session_name   = "ExpelServiceAssumeRoleForCloudTrailAccess"
+  queue_message_retention_days     = 10
 
   enable_sqs_encryption                   = true
-  enable_cloudtrail_bucket_encryption     = true
   enable_cloudtrail_log_file_validation   = true
   enable_bucket_access_logging            = true
   enable_access_logging_bucket_encryption = true
   enable_bucket_versioning                = true
   enable_bucket_encryption_key_rotation   = true
 
-  prefix = "expel-cloudtrail-integration"
+  prefix = "expel-aws-integration"
   tags = {
     "is_external" = "true"
   }

--- a/examples/basic/terraform.tfvars
+++ b/examples/basic/terraform.tfvars
@@ -1,2 +1,3 @@
-region = "Replace with the AWS region in which you want the notification queue for CloudTrail to be set up"
+region                           = "Replace with the AWS region in which you want the notification queue for CloudTrail to be set up"
 expel_customer_organization_guid = "Replace with your organization GUID assigned to you by Expel. You can find it in your browser URL after navigating to Settings > My Organization in Workbench"
+

--- a/iam.tf
+++ b/iam.tf
@@ -86,12 +86,14 @@ resource "aws_iam_policy" "cloudtrail_manager_iam_policy" {
 # tfsec:ignore:aws-iam-no-policy-wildcards
 data "aws_iam_policy_document" "cloudtrail_manager_iam_document" {
   statement {
+    sid       = "Allow Expel Workbench to get objects from cloudtrail bucket"
     actions   = ["s3:GetObject"]
     resources = ["${aws_s3_bucket.cloudtrail_bucket.arn}/*"]
     effect    = "Allow"
   }
 
   statement {
+    sid = "Allow Expel Workbench to receive & delete SQS messages"
     actions = [
       "sqs:DeleteMessage",
       "sqs:ReceiveMessage"
@@ -100,8 +102,15 @@ data "aws_iam_policy_document" "cloudtrail_manager_iam_document" {
     effect    = "Allow"
   }
 
-  # required by Expel Workbench for the gathering of information about organization's AWS footprint
   statement {
+    sid       = "Allow Expel Workbench to decrypt cloudtrail bucket"
+    actions   = ["kms:Decrypt"]
+    resources = [aws_kms_key.cloudtrail_bucket_encryption_key.arn]
+    effect    = "Allow"
+  }
+
+  statement {
+    sid = "Allow Expel Workbench to gather information about organization's AWS footprint"
     actions = [
       "cloudtrail:DescribeTrails",
       "cloudtrail:GetTrailStatus",

--- a/kms.tf
+++ b/kms.tf
@@ -1,0 +1,74 @@
+# Key policies for cloudtrail key
+data "aws_iam_policy_document" "cloudtrail_key_policy_document" {
+  statement {
+    sid    = "enable IAM User Permissions"
+    effect = "Allow"
+    principals {
+      type        = "AWS"
+      identifiers = ["arn:aws:iam::${local.customer_aws_account_id}:root"]
+    }
+    actions   = ["kms:*"]
+    resources = ["*"]
+  }
+
+  statement {
+    sid    = "Allow CloudTrail to encrypt logs"
+    effect = "Allow"
+    principals {
+      type        = "Service"
+      identifiers = ["cloudtrail.amazonaws.com"]
+    }
+    actions   = ["kms:GenerateDataKey*"]
+    resources = ["*"]
+    condition {
+      test     = "StringLike"
+      variable = "kms:EncryptionContext:aws:cloudtrail:arn"
+      values   = ["arn:aws:cloudtrail:${local.region}:${local.customer_aws_account_id}:trail/*"]
+    }
+    condition {
+      test     = "StringEquals"
+      variable = "aws:SourceArn"
+      values   = ["arn:aws:cloudtrail:${local.region}:${local.customer_aws_account_id}:trail/${var.prefix}-cloudtrail"]
+    }
+  }
+
+  statement {
+    sid    = "Allow CloudTrail to describe key"
+    effect = "Allow"
+    principals {
+      type        = "Service"
+      identifiers = ["cloudtrail.amazonaws.com"]
+    }
+    actions   = ["kms:DescribeKey"]
+    resources = ["*"]
+    condition {
+      test     = "StringLike"
+      variable = "aws:SourceArn"
+      values   = ["arn:aws:cloudtrail:*:${local.customer_aws_account_id}:trail/${var.prefix}-cloudtrail"]
+    }
+  }
+
+  statement {
+    sid    = "Allow cloudtrail bucket to encrypt/decrypt SQS queue"
+    effect = "Allow"
+    principals {
+      type        = "Service"
+      identifiers = ["s3.amazonaws.com"]
+    }
+    actions   = ["kms:GenerateDataKey", "kms:Decrypt"]
+    resources = ["*"]
+    condition {
+      test     = "StringLike"
+      variable = "aws:SourceArn"
+      values   = ["arn:aws:s3:::${var.prefix}-${random_uuid.cloudtrail_bucket_name.result}"]
+    }
+  }
+}
+
+resource "aws_kms_key" "cloudtrail_bucket_encryption_key" {
+  description         = "This key is used to encrypt cloudtrail bucket & SQS queue."
+  enable_key_rotation = var.enable_bucket_encryption_key_rotation
+  policy              = data.aws_iam_policy_document.cloudtrail_key_policy_document.json
+  tags                = local.tags
+}
+

--- a/kms.tf
+++ b/kms.tf
@@ -23,7 +23,7 @@ data "aws_iam_policy_document" "cloudtrail_key_policy_document" {
     condition {
       test     = "StringLike"
       variable = "kms:EncryptionContext:aws:cloudtrail:arn"
-      values   = ["arn:aws:cloudtrail:${local.region}:${local.customer_aws_account_id}:trail/*"]
+      values   = ["arn:aws:cloudtrail:*:${local.customer_aws_account_id}:trail/*"]
     }
     condition {
       test     = "StringEquals"
@@ -42,9 +42,9 @@ data "aws_iam_policy_document" "cloudtrail_key_policy_document" {
     actions   = ["kms:DescribeKey"]
     resources = ["*"]
     condition {
-      test     = "StringLike"
+      test     = "StringEquals"
       variable = "aws:SourceArn"
-      values   = ["arn:aws:cloudtrail:*:${local.customer_aws_account_id}:trail/${var.prefix}-cloudtrail"]
+      values   = ["arn:aws:cloudtrail:${local.region}:${local.customer_aws_account_id}:trail/${var.prefix}-cloudtrail"]
     }
   }
 
@@ -61,6 +61,11 @@ data "aws_iam_policy_document" "cloudtrail_key_policy_document" {
       test     = "StringLike"
       variable = "aws:SourceArn"
       values   = ["arn:aws:s3:::${var.prefix}-${random_uuid.cloudtrail_bucket_name.result}"]
+    }
+    condition {
+      test     = "StringEquals"
+      variable = "aws:SourceAccount"
+      values   = ["${local.customer_aws_account_id}"]
     }
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,3 @@
-# ignoring since cloudtrail is inaccessable beyond integration with S3 which uses encryption by default
-# tfsec:ignore:aws-cloudtrail-enable-at-rest-encryption
 resource "aws_cloudtrail" "cloudtrail" {
   name                  = "${var.prefix}-cloudtrail"
   is_multi_region_trail = true
@@ -7,6 +5,7 @@ resource "aws_cloudtrail" "cloudtrail" {
   s3_bucket_name        = aws_s3_bucket.cloudtrail_bucket.id
 
   enable_log_file_validation = var.enable_cloudtrail_log_file_validation
+  kms_key_id                 = aws_kms_key.cloudtrail_bucket_encryption_key.arn
 
   event_selector {
     include_management_events = true

--- a/outputs.tf
+++ b/outputs.tf
@@ -10,7 +10,7 @@ output "role_session_name" {
 
 output "aws_region" {
   description = "The AWS Region where the CloudTrail resources exist"
-  value       = data.aws_region.current.name
+  value       = local.region
 }
 
 output "sqs_queue_url" {

--- a/s3.tf
+++ b/s3.tf
@@ -1,7 +1,10 @@
+resource "random_uuid" "cloudtrail_bucket_name" {
+}
+
 # temporarily ignoring because tfsec does not yet support AWS v4 configuration
 # tfsec:ignore:aws-s3-enable-bucket-encryption tfsec:ignore:aws-s3-encryption-customer-key tfsec:ignore:aws-s3-enable-bucket-logging tfsec:ignore:aws-s3-enable-versioning
 resource "aws_s3_bucket" "cloudtrail_bucket" {
-  bucket_prefix = var.prefix
+  bucket = "${var.prefix}-${random_uuid.cloudtrail_bucket_name.result}"
 
   depends_on = [aws_sqs_queue.cloudtrail_queue]
 
@@ -23,12 +26,11 @@ resource "aws_s3_bucket_versioning" "cloudtrail_bucket_versioning" {
 }
 
 resource "aws_s3_bucket_server_side_encryption_configuration" "cloudtrail_bucket_server_side_encryption_configuration" {
-  count  = var.enable_cloudtrail_bucket_encryption ? 1 : 0
   bucket = aws_s3_bucket.cloudtrail_bucket.bucket
 
   rule {
     apply_server_side_encryption_by_default {
-      kms_master_key_id = aws_kms_key.cloudtrail_bucket_encryption_key[0].arn
+      kms_master_key_id = aws_kms_key.cloudtrail_bucket_encryption_key.arn
       sse_algorithm     = "aws:kms"
     }
   }
@@ -48,7 +50,7 @@ resource "aws_s3_bucket_logging" "cloudtrail_bucket_logging" {
 resource "aws_s3_bucket" "cloudtrail_access_log_bucket" {
   count = var.enable_bucket_access_logging ? 1 : 0
 
-  bucket_prefix = "${var.prefix}-logs"
+  bucket = "${var.prefix}-logs-${random_uuid.cloudtrail_bucket_name.result}"
 
   tags = local.tags
 }
@@ -75,27 +77,12 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "cloudtrail_access
 
   rule {
     apply_server_side_encryption_by_default {
-      kms_master_key_id = aws_kms_key.access_logging_bucket_encryption_key[0].arn
+      kms_master_key_id = aws_kms_key.cloudtrail_bucket_encryption_key.arn
       sse_algorithm     = "aws:kms"
     }
   }
 }
 
-resource "aws_kms_key" "cloudtrail_bucket_encryption_key" {
-  count = var.enable_cloudtrail_bucket_encryption ? 1 : 0
-
-  description         = "This key is used to encrypt cloudtrail bucket objects."
-  enable_key_rotation = var.enable_bucket_encryption_key_rotation
-  tags                = local.tags
-}
-
-resource "aws_kms_key" "access_logging_bucket_encryption_key" {
-  count = var.enable_access_logging_bucket_encryption ? 1 : 0
-
-  description         = "This key is used to encrypt access logging bucket objects."
-  enable_key_rotation = var.enable_bucket_encryption_key_rotation
-  tags                = local.tags
-}
 
 resource "aws_s3_bucket_public_access_block" "cloudtrail_bucket_public_access_block" {
   bucket = aws_s3_bucket.cloudtrail_bucket.id

--- a/sqs.tf
+++ b/sqs.tf
@@ -3,7 +3,7 @@
 resource "aws_sqs_queue" "cloudtrail_queue" {
   name                      = "${var.prefix}-queue"
   message_retention_seconds = var.queue_message_retention_days * 24 * 60 * 60
-  sqs_managed_sse_enabled   = var.enable_sqs_encryption
+  kms_master_key_id         = aws_kms_key.cloudtrail_bucket_encryption_key.arn
 
   tags = local.tags
 }

--- a/terraform.tf
+++ b/terraform.tf
@@ -8,6 +8,9 @@ terraform {
   required_version = ">= 1.1.0"
 }
 
+data "aws_region" "current" {}
+data "aws_caller_identity" "current" {}
+
 locals {
   default_tags = {
     "vendor" = "expel"
@@ -17,6 +20,8 @@ locals {
     var.tags,
     local.default_tags,
   )
+
+  region                  = data.aws_region.current.name
+  customer_aws_account_id = data.aws_caller_identity.current.account_id
 }
 
-data "aws_region" "current" {}

--- a/variables.tf
+++ b/variables.tf
@@ -27,8 +27,8 @@ variable "prefix" {
   default     = "expel-aws-integration"
 
   validation {
-    condition     = length(var.prefix) <= 32
-    error_message = "Prefix value must be 32 characters or less."
+    condition     = length(var.prefix) <= 26
+    error_message = "Prefix value must be 26 characters or less."
   }
 }
 
@@ -45,12 +45,6 @@ variable "queue_message_retention_days" {
 
 variable "enable_sqs_encryption" {
   description = "Enable server-side encryption (SSE) of message content with SQS-owned encryption keys."
-  type        = bool
-  default     = true
-}
-
-variable "enable_cloudtrail_bucket_encryption" {
-  description = "Enable to encrypt objects in the cloudtrail bucket."
   type        = bool
   default     = true
 }


### PR DESCRIPTION
> Based on the discussion & recommendations from [this doc](https://docs.google.com/document/d/1Xf0bmpnKhsCizL66hVVqMdvt7ztUZn2fkGMVUSoK4Vw/edit#), we are encrypting Cloudtrail logs, Cloudtrail bucket (non-optional) & optionally Cloudtrail bucket log-bucket using a custom KMS key. This PR also adds necessary KMS key policies & IAM policies for relevant AWS principals(AWS roles & services) to grant required access to the key.