### PR TITLE
Remove IAM SID properties

### DIFF
--- a/iam.tf
+++ b/iam.tf
@@ -93,7 +93,7 @@ data "aws_iam_policy_document" "cloudtrail_manager_iam_document" {
   }
 
   statement {
-    sid = "Allow Expel Workbench to receive & delete SQS messages"
+    sid = "Allow Expel Workbench to receive and delete SQS messages"
     actions = [
       "sqs:DeleteMessage",
       "sqs:ReceiveMessage"
@@ -110,7 +110,7 @@ data "aws_iam_policy_document" "cloudtrail_manager_iam_document" {
   }
 
   statement {
-    sid = "Allow Expel Workbench to gather information about organization's AWS footprint"
+    sid = "Allow Expel Workbench to gather information about AWS footprint"
     actions = [
       "cloudtrail:DescribeTrails",
       "cloudtrail:GetTrailStatus",

--- a/kms.tf
+++ b/kms.tf
@@ -28,7 +28,7 @@ data "aws_iam_policy_document" "cloudtrail_key_policy_document" {
     condition {
       test     = "StringEquals"
       variable = "aws:SourceArn"
-      values   = ["arn:aws:cloudtrail:${local.region}:${local.customer_aws_account_id}:trail/${var.prefix}-cloudtrail"]
+      values   = ["arn:aws:cloudtrail:${local.region}:${local.customer_aws_account_id}:trail/${var.prefix}-trail"]
     }
   }
 
@@ -44,7 +44,7 @@ data "aws_iam_policy_document" "cloudtrail_key_policy_document" {
     condition {
       test     = "StringEquals"
       variable = "aws:SourceArn"
-      values   = ["arn:aws:cloudtrail:${local.region}:${local.customer_aws_account_id}:trail/${var.prefix}-cloudtrail"]
+      values   = ["arn:aws:cloudtrail:${local.region}:${local.customer_aws_account_id}:trail/${var.prefix}-trail"]
     }
   }
 

--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,5 @@
 resource "aws_cloudtrail" "cloudtrail" {
-  name                  = "${var.prefix}-cloudtrail"
+  name                  = "${var.prefix}-trail"
   is_multi_region_trail = true
   is_organization_trail = var.enable_organization_trail
   s3_bucket_name        = aws_s3_bucket.cloudtrail_bucket.id


### PR DESCRIPTION
### Changed
- Add comments to statements to replace description from SID properties (turns out SIDs on policy doc statements have alphanumeric validation)
- Rename cloudtrail entity suffix from `cloudtrail` to `trail` so that default prefix stutters less on the CloudTrail name (`expel-aws-cloudtrail-cloudtrail` -> `expel-aws-cloudtrail-trail`)