### PR TITLE
Remove temporary tfsec ignore statements

### DIFF
--- a/s3.tf
+++ b/s3.tf
@@ -1,8 +1,6 @@
 resource "random_uuid" "cloudtrail_bucket_name" {
 }
 
-# temporarily ignoring because tfsec does not yet support AWS v4 configuration
-# tfsec:ignore:aws-s3-enable-bucket-encryption tfsec:ignore:aws-s3-encryption-customer-key tfsec:ignore:aws-s3-enable-bucket-logging tfsec:ignore:aws-s3-enable-versioning
 resource "aws_s3_bucket" "cloudtrail_bucket" {
   bucket = "${var.prefix}-${random_uuid.cloudtrail_bucket_name.result}"
 
@@ -45,8 +43,6 @@ resource "aws_s3_bucket_logging" "cloudtrail_bucket_logging" {
   target_prefix = "log/"
 }
 
-# temporarily ignoring because tfsec does not yet support AWS v4 configuration
-# tfsec:ignore:aws-s3-enable-bucket-encryption tfsec:ignore:aws-s3-encryption-customer-key tfsec:ignore:aws-s3-enable-bucket-logging tfsec:ignore:aws-s3-enable-versioning
 resource "aws_s3_bucket" "cloudtrail_access_log_bucket" {
   count = var.enable_bucket_access_logging ? 1 : 0
 

--- a/sqs.tf
+++ b/sqs.tf
@@ -1,5 +1,3 @@
-# ignoring because SSE encryption is enabled by default
-# tfsec:ignore:aws-sqs-enable-queue-encryption
 resource "aws_sqs_queue" "cloudtrail_queue" {
   name                      = "${var.prefix}-queue"
   message_retention_seconds = var.queue_message_retention_days * 24 * 60 * 60


### PR DESCRIPTION
### Removed
- tfsec ignore comments have been removed which were previously used to ignore security concerns that were inaccurate because tfsec had not at the time been updated to handle AWS's v4 Terraform implementation.