### PR TITLE
TME-1154: fix iam role name

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Configures a CloudTrail stack (CloudTrail & S3 bucket) with a notification queue
 ```hcl
 module "expel_aws_cloudtrail" {
   source  = "expel-io/cloudtrail/aws"
-  version = "1.2.0"
+  version = "1.2.1"
 
   expel_customer_organization_guid = "Replace with your organization GUID from Expel Workbench"
   region = "AWS region in which notification queue for CloudTrail will be created"

--- a/iam.tf
+++ b/iam.tf
@@ -66,7 +66,7 @@ data "aws_iam_policy_document" "assume_role_iam_document" {
 }
 
 resource "aws_iam_role" "expel_assume_role" {
-  name               = "ExpelServiceAssumeRole"
+  name               = "ExpelTrailAssumeRole"
   assume_role_policy = data.aws_iam_policy_document.assume_role_iam_document.json
 
   tags = local.tags

--- a/stackset.tf
+++ b/stackset.tf
@@ -13,6 +13,7 @@ resource "aws_cloudformation_stack_set" "permeate_account_policy" {
   parameters = {
     ExpelCustomerOrganizationGUID = var.expel_customer_organization_guid,
     ExpelAssumeRoleARN            = aws_iam_role.expel_assume_role.arn
+    ExpelRoleName                 = aws_iam_role.expel_assume_role.name
   }
 
   template_body = local.stackset_template

--- a/stackset_template.tf
+++ b/stackset_template.tf
@@ -9,6 +9,9 @@ locals {
         },
          "ExpelAssumeRoleARN" : {
             "Type" : "String"
+        },
+        "ExpelRoleName" : {
+            "Type" : "String"
         }
     },
     "Resources": {
@@ -20,7 +23,7 @@ locals {
                         "Ref": "IAMMP12SQ7"
                     }
                 ],
-                "RoleName": "ExpelRole",
+                "RoleName": { "Ref": "ExpelRoleName" },
                 "AssumeRolePolicyDocument": {
                     "Version": "2012-10-17",
                     "Statement": [


### PR DESCRIPTION
> We want to have the same IAM role name for stackset & the role deployed in the mgmt account since the integration can only assume 1 role. Also making role name specific to the integration to avoid role name conflict with other aws integrations (eg: guardduty). 