### PR TITLE
MET-443 adding DescribeOrganization permission

### DIFF
--- a/iam.tf
+++ b/iam.tf
@@ -158,6 +158,7 @@ data "aws_iam_policy_document" "cloudtrail_manager_iam_document" {
       "lambda:ListFunctions",
       "lightsail:GetInstances",
       "lightsail:GetRegions",
+      "organizations:DescribeOrganization",
       "organizations:ListAccounts",
       "rds:DescribeDBInstances",
       "rds:ListTagsForResource",

--- a/stackset_template.tf
+++ b/stackset_template.tf
@@ -77,6 +77,7 @@ locals {
                                 "lambda:ListFunctions",
                                 "lightsail:GetInstances",
                                 "lightsail:GetRegions",
+                                "organizations:DescribeOrganization",
                                 "organizations:ListAccounts",
                                 "rds:DescribeDBInstances",
                                 "rds:ListTagsForResource",


### PR DESCRIPTION
We don't have a way to know whether an account onboarded is the management account, even if the management account ID is provided (it can be wrong). Adding DescribeOrganization permission so we can determine whether an account is the organization management account.