### PR TITLE
TME-2253: Update New CloudTrail ACL Configurations

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,10 +91,9 @@ Please contact your Engagement Manager if you have an existing CloudTrail with a
 | [aws_kms_key.notification_encryption_key](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_key) | resource |
 | [aws_s3_bucket.cloudtrail_access_log_bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket) | resource |
 | [aws_s3_bucket.cloudtrail_bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket) | resource |
-| [aws_s3_bucket_acl.cloudtrail_access_log_bucket_acl](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_acl) | resource |
-| [aws_s3_bucket_acl.cloudtrail_bucket_acl](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_acl) | resource |
 | [aws_s3_bucket_logging.cloudtrail_bucket_logging](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_logging) | resource |
 | [aws_s3_bucket_notification.cloudtrail_bucket_notification](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_notification) | resource |
+| [aws_s3_bucket_policy.cloudtrail_access_log_bucket_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_policy) | resource |
 | [aws_s3_bucket_policy.cloudtrail_bucket_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_policy) | resource |
 | [aws_s3_bucket_public_access_block.cloudtrail_access_log_bucket_public_access_block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_public_access_block) | resource |
 | [aws_s3_bucket_public_access_block.cloudtrail_bucket_public_access_block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_public_access_block) | resource |


### PR DESCRIPTION
**Description:** 

Updates the S3 terraform configuration to address a [recent change](https://aws.amazon.com/about-aws/whats-new/2022/12/amazon-s3-automatically-enable-block-public-access-disable-access-control-lists-buckets-april-2023/) made with respect to how AWS handles defaults for Access Control Lists on S3 buckets. Going forward all new S3 buckets will default their object ownership setting to `bucket owner enforced`, which means that requests to set/update ACLs will fail as well.

**Detailed list or summary of changes made:**

- Removes the [cloudtrail_bucket_acl configuration](https://github.com/expel-io/terraform-aws-cloudtrail/pull/44/files#diff-beadbc29548607cf77c3c6882a0c49559eb088a560805d12a445c52f80f07b31L15-L20). This isn't necessary since this is the default behavior of new S3 buckets.

- Refactors the [cloudtrail_access_log_bucket_acl configuration](https://github.com/expel-io/terraform-aws-cloudtrail/pull/44/files#diff-beadbc29548607cf77c3c6882a0c49559eb088a560805d12a445c52f80f07b31L61) into a S3 bucket policy statement instead of the canned ACL setting.

**Steps to test/reproduce the changes in this PR:**

- Create a test terraform file (ex. `main.tf`).
- Implement the following module.
```
module "expel_aws_cloudtrail_integration" {
  source  = "expel-io/cloudtrail/aws"
  version = "1.3.4"

  expel_customer_organization_guid = "<expel_organization_id>"
  enable_organization_trail = false
}

output "cloudtrail_integration" {
  value = module.expel_aws_cloudtrail_integration
}
```
- Applying the above configuration should result in an error along the lines of
```
AccessControlListNotSupported: The bucket does not allow ACLs │ status code: 400
```