### PR TITLE
TME-2291: Update stackset expel principal arn

### DIFF
--- a/s3.tf
+++ b/s3.tf
@@ -1,5 +1,3 @@
-# ignoring to maintain parity with other cloudtrail onboarding methods
-# tfsec:ignore:aws-s3-enable-bucket-logging
 resource "random_uuid" "cloudtrail_bucket_name" {
   count = var.existing_cloudtrail_bucket_name == null ? 1 : 0
 }
@@ -45,6 +43,8 @@ resource "aws_s3_bucket_logging" "cloudtrail_bucket_logging" {
   target_prefix = "log/"
 }
 
+# ignoring as the logging block is deprecated in favor of aws_s3_bucket_logging
+# tfsec:ignore:aws-s3-enable-bucket-logging
 resource "aws_s3_bucket" "cloudtrail_access_log_bucket" {
   count = var.existing_cloudtrail_bucket_name == null && var.enable_bucket_access_logging ? 1 : 0
 

--- a/s3.tf
+++ b/s3.tf
@@ -1,3 +1,5 @@
+# ignoring to maintain parity with other cloudtrail onboarding methods
+# tfsec:ignore:aws-s3-enable-bucket-logging
 resource "random_uuid" "cloudtrail_bucket_name" {
   count = var.existing_cloudtrail_bucket_name == null ? 1 : 0
 }

--- a/stackset.tf
+++ b/stackset.tf
@@ -11,8 +11,8 @@ resource "aws_cloudformation_stack_set" "permeate_account_policy" {
   }
 
   parameters = {
-    ExpelCustomerOrganizationGUID = var.expel_customer_organization_guid,
-    ExpelAssumeRoleARN            = aws_iam_role.expel_assume_role.arn
+    ExpelCustomerOrganizationGUID = var.expel_customer_organization_guid
+    ExpelAccountARN               = var.expel_aws_account_arn
     ExpelRoleName                 = aws_iam_role.expel_assume_role.name
   }
 

--- a/stackset_template.tf
+++ b/stackset_template.tf
@@ -7,7 +7,7 @@ locals {
         "ExpelCustomerOrganizationGUID" : {
             "Type" : "String"
         },
-         "ExpelAssumeRoleARN" : {
+         "ExpelAccountARN" : {
             "Type" : "String"
         },
         "ExpelRoleName" : {
@@ -30,7 +30,7 @@ locals {
                         {
                             "Effect": "Allow",
                             "Principal": {
-                                "AWS": { "Ref": "ExpelAssumeRoleARN" }
+                                "AWS": { "Ref": "ExpelAccountARN" }
                             },
                             "Action": "sts:AssumeRole",
                             "Condition": {


### PR DESCRIPTION
Updates the principal account arn to point directly to the Expel AWS account when establishing the trust relationship instead of going through the created IAM role as is currently being done.

This PR has been tested to validate that no regressions were introduced.