### PR TITLE
Updating CircleCI orb config.yml to expel-io/apps@1.8.6

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 
 orbs:
   terraform: circleci/terraform@3.0.0
-  apps: expel-io/apps@1.5.0
+  apps: expel-io/apps@1.8.6
 
 workflows:
   quality-check:


### PR DESCRIPTION
Hello!

The Developer Experience team has created this pull request to help you upgrade the `expel-io/apps` CircleCI orb to `1.8.6`. 

**Sept. 30, 2024** is when Expel CircleCI orb versions prior to `1.8.3` referencing [end of life](https://discuss.circleci.com/t/linux-image-deprecations-and-eol-for-2024/50177) base images will be removed from CircleCI's platform.

**Your builds will fail** on the following dates and times - in case you aren't able to immediately merge this pull request - due to CircleCI conducting brownouts:
- 4 March 2024
  - 07:00 UTC → 11:00 UTC
  - 13:00 UTC → 17:00 UTC
  - 20:00 UTC → 00:00 UTC
- 28 May 2024
  - 02:00 UTC → 10:00 UTC
  - 14:00 UTC → 22:00 UTC
  - 28 August 2024
  - 00:00 UTC → 00:00 UTC (24 Hour)
- 17 September 2024
  - 00:00 UTC → 00:00 UTC (24 Hour)
- 30 September 2024
  - Deprecated tags are removed and will be unavailable

This is following up on the [DX team's Slack post in Engineering](https://expletives.slack.com/archives/C0103UGR31T/p1709571297723179).

This PR was produced by an automated script to update all CircleCI Yaml configurations using the `expel-io/apps` orb between versions `1.0.0` and `1.8.2`.