### PR TITLE
TME-2703: Upgrade hashicorp aws dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,8 +103,8 @@ Please read our [Contributing Code of Conduct](CONTRIBUTING.md) to get started.
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | ~> 1.1 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 4.7 |
-| <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.1 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.46 |
+| <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.6 |
 ## Inputs
 
 | Name | Description | Type | Default | Required |

--- a/terraform.tf
+++ b/terraform.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.7"
+      version = "~> 5.46"
       # For new & existing cloudtrail with resources in single aws account, set the log_bucket alias to default aws provider.
       # For existing cloudtrail with resources in different aws accounts, create an aws provider for the log_bucket account & pass it's alias.
       # See examples for reference.
@@ -11,7 +11,7 @@ terraform {
 
     random = {
       source  = "hashicorp/random"
-      version = "~> 3.1"
+      version = "~> 3.6"
     }
   }
   required_version = "~> 1.1"


### PR DESCRIPTION
- Upgrades the hashicorp/aws dependency requirement to `~> 5.46` ([changelog](https://github.com/hashicorp/terraform-provider-aws/compare/v4.7.0...v5.46.0))
- Upgrades the `hashicorp/random` dependency requirement to `~> 3.6` ([changelog](https://github.com/hashicorp/terraform-provider-random/compare/v3.1.0...v3.6.1))