### PR TITLE
Update: Adds support for specifying optional assume role

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ Please read our [Contributing Code of Conduct](CONTRIBUTING.md) to get started.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_expel_customer_organization_guid"></a> [expel\_customer\_organization\_guid](#input\_expel\_customer\_organization\_guid) | Expel customer's organization GUID assigned to you by Expel. You can find it in your browser URL after navigating to Settings > My Organization in Workbench. | `string` | n/a | yes |
+| <a name="input_assume_role_arn"></a> [assume\_role\_arn](#input\_assume\_role\_arn) | ARN of the IAM role being assumed for resource creation | `string` | `null` | no |
 | <a name="input_aws_management_account_id"></a> [aws\_management\_account\_id](#input\_aws\_management\_account\_id) | Account id of AWS management account. | `string` | `null` | no |
 | <a name="input_enable_access_logging_bucket_encryption"></a> [enable\_access\_logging\_bucket\_encryption](#input\_enable\_access\_logging\_bucket\_encryption) | Enable to encrypt objects in the access logging bucket. | `bool` | `true` | no |
 | <a name="input_enable_bucket_access_logging"></a> [enable\_bucket\_access\_logging](#input\_enable\_bucket\_access\_logging) | Access logging provides detailed records for the requests that are made to an Amazon S3 bucket. | `bool` | `true` | no |

--- a/variables.tf
+++ b/variables.tf
@@ -60,6 +60,11 @@ variable "enable_organization_trail" {
 }
 
 /* --- Set these variables to support CloudTrail configuration --- */
+variable "assume_role_arn" {
+  type        = string
+  description = "ARN of the IAM role being assumed for resource creation"
+  default     = null
+}
 
 variable "is_existing_cloudtrail_cross_account" {
   description = "For an existing cloudtrail, whether the cloudtrail & the log bucket (& optionally log bucket notifier topic if existing) are in different aws accounts"


### PR DESCRIPTION
Adds support for passing in an optional role arn argument for instances in which the module configuration is being applied via an assumed role.
- Updates the relevant kms key policies to include this optional role as another principal. Otherwise it'll attempt to infer the current caller via the `aws_caller_identity`.