### PR TITLE
TME-2706/TME-2712: cleanup kms key root identifiers

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,7 @@ Please read our [Contributing Code of Conduct](CONTRIBUTING.md) to get started.
 | [aws_iam_policy_document.notification_key_policy_document](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.sns_queue_iam_document](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.sns_topic_iam_document](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_session_context.current_source_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_session_context) | data source |
 | [aws_organizations_organization.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/organizations_organization) | data source |
 | [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
 <!-- end-tf-docs -->

--- a/kms.tf
+++ b/kms.tf
@@ -1,6 +1,6 @@
 locals {
-  provisioner_role_arn         = var.assume_role_arn == null ? data.aws_caller_identity.current.arn : var.assume_role_arn
-  cloudtrail_key_policy_root   = var.is_existing_cloudtrail_cross_account == false ? "arn:aws:iam::${local.customer_aws_account_id}:root" : "arn:aws:iam::${var.existing_cloudtrail_log_bucket_account_id}:root"
+  provisioner_role_arn         = var.assume_role_arn == null ? data.aws_iam_session_context.current_source_role.issuer_arn : var.assume_role_arn
+  cloudtrail_key_policy_root   = "arn:aws:iam::${local.customer_aws_account_id}:root" #only used for new cloudtrails
   notification_key_policy_root = var.is_existing_cloudtrail_cross_account == false ? "arn:aws:iam::${local.customer_aws_account_id}:root" : "arn:aws:iam::${var.existing_cloudtrail_log_bucket_account_id}:root"
 }
 

--- a/locals.tf
+++ b/locals.tf
@@ -6,6 +6,10 @@ data "aws_region" "current" {}
 # Fetch the current AWS caller identity
 data "aws_caller_identity" "current" {}
 
+# Fetch the source role of current caller if it is an STS assumed role
+data "aws_iam_session_context" "current_source_role" {
+  arn = data.aws_caller_identity.current.arn
+}
 # Fetch the current AWS organization if organization trail is enabled
 data "aws_organizations_organization" "current" {
   count = var.enable_organization_trail ? 1 : 0


### PR DESCRIPTION
- Set cloudtrail KMS key root as the cloudtrail account
- Set notification KMS key root as the source arn of the current TF user/role 