### PR TITLE
Issue: Update semantic versioning for aws provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,9 +102,9 @@ Please read our [Contributing Code of Conduct](CONTRIBUTING.md) to get started.
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | ~> 1.1 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.0 |
-| <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.6 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.1 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.0 |
+| <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.6 |
 ## Inputs
 
 | Name | Description | Type | Default | Required |

--- a/terraform.tf
+++ b/terraform.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.0"
+      version = ">= 5.0"
       # For new & existing cloudtrail with resources in single aws account, set the log_bucket alias to default aws provider.
       # For existing cloudtrail with resources in different aws accounts, create an aws provider for the log_bucket account & pass it's alias.
       # See examples for reference.
@@ -11,8 +11,8 @@ terraform {
 
     random = {
       source  = "hashicorp/random"
-      version = "~> 3.6"
+      version = ">= 3.6"
     }
   }
-  required_version = "~> 1.1"
+  required_version = ">= 1.1"
 }


### PR DESCRIPTION
Updating the version constraint for the aws provider to adhere to [Terraform best practices](https://developer.hashicorp.com/terraform/language/expressions/version-constraints#terraform-core-and-provider-versions) regarding reusable modules. This allows consumers running higher major versions to still utilize the module as necessary.